### PR TITLE
chore: adding repo to private github package

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,33 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12
+      - run: npm ci
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "keystone-cloudinary-s3-proxy",
+  "name": "@BioRender-Team/keystone-cloudinary-s3-proxy",
   "version": "1.0.0",
   "description": "proxy between keystone and cloudinary that also updates s3",
   "main": "index.js",
@@ -10,6 +10,10 @@
     "type": "git",
     "url": "git+https://github.com/BioRender-Team/keystone-cloudinary-s3-proxy.git"
   },
+  "publishConfig": {
+    "@BioRender-Team:registry": "https://npm.pkg.github.com"
+  },
+
   "author": "biorender",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
Motivation:

The repo is being made private, but it is currently referenced by `biorender-team/keystone-v4` repo as a dep.  Making this into a private github package so the keystone-v4 repo will continue to build